### PR TITLE
Fix undefined categoryAliases

### DIFF
--- a/src/services/printful.ts
+++ b/src/services/printful.ts
@@ -68,7 +68,7 @@ class PrintfulService extends TransactionBaseService {
         this.storeId = options.storeId;
         this.productTags = options.productTags;
         this.productCategories = options.productCategories;
-        this.categoryAliases = options.categoryAliases
+        this.categoryAliases = options.categoryAliases ?? { exactMatch: {}, inexactMatch: {} }
         this.confirmOrder = options.confirmOrder || false;
 
         this.backoffOptions = {


### PR DESCRIPTION
I had some issues with a new medusajs trying this plugin.
it was failing due to categoryAliases were not defined.
Adding this fallback fixes creating categories.