### PR TITLE
Fix options in variants

### DIFF
--- a/src/services/printful.ts
+++ b/src/services/printful.ts
@@ -466,11 +466,11 @@ class PrintfulService extends TransactionBaseService {
                             inventory_quantity: 100,
                             allow_backorder: true,
                             manage_inventory: false,
-                            options,
                             prices: [{
                                 amount: this.convertToInteger(variant.retail_price),
                                 currency_code: variant.currency.toLowerCase()
                             }],
+                            options
                         });
 
                         if (newVariant) {
@@ -482,13 +482,11 @@ class PrintfulService extends TransactionBaseService {
                                 medusa_id: newVariant.id,
                                 printful_id: variant.id,
                                 printful_catalog_variant_id: variant.variant_id,
-                                size: option.size,
+                                ...(option.size ? {size: option.size} : {}),
+                                ...(option.color ? {color: option.color} : {}),
+                                ...(option.color_code ? {color_code: option.color_code} : {}),
                                 ...productSizeGuide
                             };
-                            if(option.color) {
-                                metadata.color = option.color
-                                metadata.color_code = option.color_code
-                            }
                             return {
                                 title,
                                 sku: variant.sku,

--- a/src/services/printful.ts
+++ b/src/services/printful.ts
@@ -244,12 +244,6 @@ class PrintfulService extends TransactionBaseService {
                     const getVariantOptions = async () => {
                         const {result: {variant: option}} = await this.printfulClient.get(`products/variant/${variant_id}`);
 
-                        const options = {
-                            ...(option.size ? {size: option.size} : {}),
-                            ...(option.color ? {color: option.color} : {}),
-                            ...(option.color_code ? {color_code: option.color_code} : {})
-                        }
-
                         const metadata = {
                             brand: product.name,
                             printful_id: id,
@@ -257,12 +251,16 @@ class PrintfulService extends TransactionBaseService {
                             printful_product_id: product.product_id,
                             printful_catalog_product_id: product.id,
                             size_tables: productSizeGuide?.size_tables ?? null,
-                            ...options
+                            ...(option.size && { size: option.size }),
+                            ...(option.color && { color: option.color }),
+                            ...(option.color_code && { color_code: option.color_code })
                         }
-                        if(option.color) {
-                            metadata.color = option.color;
-                            metadata.color_code = option.color_code;
-                        }
+
+                        const options = [
+                            ...(option.size ? [{ value: option.size }] : []),
+                            ...(option.color ? [{ value: option.color }] : []),
+                            ...(option.color_code ? [{ value: option.color_code }] : [])
+                        ];
 
                         return {
                             title: productObj.title + (option.size ? ` - ${option.size}` : '') + (option.color ? ` / ${option.color}` : ''),
@@ -409,24 +407,21 @@ class PrintfulService extends TransactionBaseService {
                     if (medusaVariant !== undefined) {
                         const title = productObj.title + (option.size ? ` - ${option.size}` : '') + (option.color ? ` / ${option.color}` : '');
 
-                        const options = {
-                            ...(option.size ? {size: option.size} : {}),
-                            ...(option.color ? {color: option.color} : {}),
-                            ...(option.color_code ? {color_code: option.color_code} : {})
-                        }
-
                         const metadata = {
                             medusa_id: medusaVariant.id,
                             printful_id: variant.id,
                             printful_catalog_variant_id: variant.variant_id,
                             size: option.size,
-                            ...productSizeGuide
+                            ...(option.color && { color: option.color }),
+                            ...(option.color_code && { color_code: option.color_code }),
+                            ...productSizeGuide,
                         };
 
-                        if(option.color) {
-                            metadata.color = option.color
-                            metadata.color_code = option.color_code
-                        }
+                        const options = [
+                            ...(option.size ? [{ value: option.size }] : []),
+                            ...(option.color ? [{ value: option.color }] : []),
+                            ...(option.color_code ? [{ value: option.color_code }] : [])
+                        ];
 
                         return {
                             title,

--- a/src/services/printful.ts
+++ b/src/services/printful.ts
@@ -412,6 +412,7 @@ class PrintfulService extends TransactionBaseService {
                         const options = {
                             ...(option.size ? {size: option.size} : {}),
                             ...(option.color ? {color: option.color} : {}),
+                            ...(option.color_code ? {color_code: option.color_code} : {})
                         }
 
                         const metadata = {
@@ -442,6 +443,7 @@ class PrintfulService extends TransactionBaseService {
 
                         const sizeOptionId = medusaProduct.options.find(o => o.title === 'size')?.id ?? null;
                         const colorOptionId = medusaProduct.options.find(o => o.title === 'color')?.id ?? null;
+                        const colorCodeOptionId = medusaProduct.options.find(o => o.title === 'color_code')?.id ?? null;
 
                         const options = [];
                         if (sizeOptionId) {
@@ -454,6 +456,12 @@ class PrintfulService extends TransactionBaseService {
                             options.push({
                                 option_id: colorOptionId,
                                 value: option.color
+                            })
+                        }
+                        if (colorCodeOptionId) {
+                            options.push({
+                                option_id: colorCodeOptionId,
+                                value: option.color_code
                             })
                         }
 

--- a/src/services/printful.ts
+++ b/src/services/printful.ts
@@ -275,7 +275,8 @@ class PrintfulService extends TransactionBaseService {
                                 amount: this.convertToInteger(retail_price),
                                 currency_code: currency.toLowerCase()
                             }],
-                            metadata
+                            metadata,
+                            options
                         }
                     }
                     const variantOptions = await backOff(getVariantOptions, this.backoffOptions);
@@ -407,6 +408,12 @@ class PrintfulService extends TransactionBaseService {
 
                     if (medusaVariant !== undefined) {
                         const title = productObj.title + (option.size ? ` - ${option.size}` : '') + (option.color ? ` / ${option.color}` : '');
+
+                        const options = {
+                            ...(option.size ? {size: option.size} : {}),
+                            ...(option.color ? {color: option.color} : {}),
+                        }
+
                         const metadata = {
                             medusa_id: medusaVariant.id,
                             printful_id: variant.id,
@@ -427,7 +434,8 @@ class PrintfulService extends TransactionBaseService {
                                 amount: this.convertToInteger(variant.retail_price),
                                 currency_code: variant.currency.toLowerCase()
                             }],
-                            metadata
+                            metadata,
+                            options
                         };
                     } else {
                         console.log(`${blue('[medusa-plugin-printful]')} Creating new variant for product ${blue(medusaProduct.id)}...`);
@@ -485,7 +493,8 @@ class PrintfulService extends TransactionBaseService {
                                     amount: this.convertToInteger(variant.retail_price),
                                     currency_code: variant.currency.toLowerCase()
                                 }],
-                                metadata
+                                metadata,
+                                options
                             };
 
                         }

--- a/src/services/printful.ts
+++ b/src/services/printful.ts
@@ -251,9 +251,9 @@ class PrintfulService extends TransactionBaseService {
                             printful_product_id: product.product_id,
                             printful_catalog_product_id: product.id,
                             size_tables: productSizeGuide?.size_tables ?? null,
-                            ...(option.size && { size: option.size }),
-                            ...(option.color && { color: option.color }),
-                            ...(option.color_code && { color_code: option.color_code })
+                            ...(option.size ? {size: option.size} : {}),
+                            ...(option.color ? {color: option.color} : {}),
+                            ...(option.color_code ? {color_code: option.color_code} : {})
                         }
 
                         const options = [
@@ -412,8 +412,8 @@ class PrintfulService extends TransactionBaseService {
                             printful_id: variant.id,
                             printful_catalog_variant_id: variant.variant_id,
                             size: option.size,
-                            ...(option.color && { color: option.color }),
-                            ...(option.color_code && { color_code: option.color_code }),
+                            ...(option.color ? {color: option.color} : {}),
+                            ...(option.color_code ? {color_code: option.color_code} : {}),
                             ...productSizeGuide,
                         };
 

--- a/src/services/printful.ts
+++ b/src/services/printful.ts
@@ -411,7 +411,7 @@ class PrintfulService extends TransactionBaseService {
                             medusa_id: medusaVariant.id,
                             printful_id: variant.id,
                             printful_catalog_variant_id: variant.variant_id,
-                            size: option.size,
+                            ...(option.size ? {size: option.size} : {}),
                             ...(option.color ? {color: option.color} : {}),
                             ...(option.color_code ? {color_code: option.color_code} : {}),
                             ...productSizeGuide,

--- a/src/services/printful.ts
+++ b/src/services/printful.ts
@@ -259,7 +259,6 @@ class PrintfulService extends TransactionBaseService {
                         const options = [
                             ...(option.size ? [{ value: option.size }] : []),
                             ...(option.color ? [{ value: option.color }] : []),
-                            ...(option.color_code ? [{ value: option.color_code }] : [])
                         ];
 
                         return {
@@ -420,7 +419,6 @@ class PrintfulService extends TransactionBaseService {
                         const options = [
                             ...(option.size ? [{ value: option.size }] : []),
                             ...(option.color ? [{ value: option.color }] : []),
-                            ...(option.color_code ? [{ value: option.color_code }] : [])
                         ];
 
                         return {
@@ -438,7 +436,6 @@ class PrintfulService extends TransactionBaseService {
 
                         const sizeOptionId = medusaProduct.options.find(o => o.title === 'size')?.id ?? null;
                         const colorOptionId = medusaProduct.options.find(o => o.title === 'color')?.id ?? null;
-                        const colorCodeOptionId = medusaProduct.options.find(o => o.title === 'color_code')?.id ?? null;
 
                         const options = [];
                         if (sizeOptionId) {
@@ -451,12 +448,6 @@ class PrintfulService extends TransactionBaseService {
                             options.push({
                                 option_id: colorOptionId,
                                 value: option.color
-                            })
-                        }
-                        if (colorCodeOptionId) {
-                            options.push({
-                                option_id: colorCodeOptionId,
-                                value: option.color_code
                             })
                         }
 

--- a/src/services/printful.ts
+++ b/src/services/printful.ts
@@ -294,27 +294,6 @@ class PrintfulService extends TransactionBaseService {
             try {
                 const createdProduct = await this.productService.create(productToPush);
                 console.log(`${green('[medusa-plugin-printful]:')} Created product in Medusa: ${green(createdProduct.id)}`);
-                if (createdProduct) {
-                    console.log(`${blue("[medusa-plugin-printful]:")} Trying to add options to variants...`);
-                    const {variants, options} = await this.productService.retrieve(createdProduct.id, {
-                        relations: ['variants', 'options'],
-                    });
-
-
-                    for (const option of options) {
-                        for (const variant of variants) {
-                            if (option.title === 'size' || option.title === 'color') {
-                                const value = variant.metadata[option.title];
-                                if (value !== null) {
-                                    const addedOption = await this.productVariantService.addOptionValue(variant.id, option.id, value as string);
-                                    if (addedOption) {
-                                        console.log(`${green('[medusa-plugin-printful]:')} Updated variant ${variant.id} option ${option.id} to ${value}! ✅`);
-                                    }
-                                }
-                            }
-                        }
-                    }
-                }
             } catch (e) {
                 console.error(`${red("[medusa-plugin-printful]:")} There appeared an error trying to create '${red(productObj.title)}' in Medusa: `, e)
                 throw e


### PR DESCRIPTION
After checking the other draft [PR](https://github.com/fsyntax/medusa-plugin-printful/pull/5)
I tested out and created a PR that defines the variant.options when creating/updating a product.

I assume that there has been medusa core changes where when creating a variant you have also to supply the options.

After making the sync to work I realised that the variant options were duplicated. So I removed the function that re-creates the variants that are created in the createProduct.
I didnt remove the updateVariant options. I think it can stay